### PR TITLE
chore: rename org to web-infra-dev

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 100
 
       - name: Create Release Pull Request
-        uses: modern-js-dev/actions@main
+        uses: web-infra-dev/actions@main
         with:
           # this expects you to have a script called release which does a build for your packages and calls changeset publish
           version: ${{ github.event.inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Release
-        uses: modern-js-dev/actions@main
+        uses: web-infra-dev/actions@main
         with:
           # this expects you to have a script called release which does a build for your packages and calls changeset publish
           version: ${{ github.event.inputs.version }}

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "name": "codesmith-monorepo",
   "description": "The meta-framework suite designed from scratch for frontend-focused modern web development.",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/api/app/README.md
+++ b/packages/api/app/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/api/app/package.json
+++ b/packages/api/app/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-api-app",
   "description": "codesmith app api",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/api/ejs/README.md
+++ b/packages/api/ejs/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/api/ejs/package.json
+++ b/packages/api/ejs/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-api-ejs",
   "description": "codesmith ejs api",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/api/fs/README.md
+++ b/packages/api/fs/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/api/fs/package.json
+++ b/packages/api/fs/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-api-fs",
   "description": "codesmith fs api",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/api/git/README.md
+++ b/packages/api/git/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/api/git/package.json
+++ b/packages/api/git/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-api-git",
   "description": "codesmith git api",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/api/handlebars/README.md
+++ b/packages/api/handlebars/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/api/handlebars/package.json
+++ b/packages/api/handlebars/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-api-handlebars",
   "description": "codesmith handlebars api",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/api/json/README.md
+++ b/packages/api/json/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/api/json/package.json
+++ b/packages/api/json/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-api-json",
   "description": "codesmith json api",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/api/npm/README.md
+++ b/packages/api/npm/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/api/npm/package.json
+++ b/packages/api/npm/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-api-npm",
   "description": "codesmith npm api",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-cli",
   "description": "codesmith cli tools",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith",
   "description": "codesmith core implement",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/easy-form/cli/README.md
+++ b/packages/easy-form/cli/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/easy-form/cli/package.json
+++ b/packages/easy-form/cli/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/easy-form-cli",
   "description": "easy form schema to cli question implement",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/easy-form/core/README.md
+++ b/packages/easy-form/core/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/easy-form/core/package.json
+++ b/packages/easy-form/core/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/easy-form-core",
   "description": "easy form json schema implement",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/formily/README.md
+++ b/packages/formily/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/formily/package.json
+++ b/packages/formily/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/codesmith-formily",
   "description": "codesmith support formly schema to inquirer question",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",

--- a/packages/inquirer/README.md
+++ b/packages/inquirer/README.md
@@ -27,4 +27,4 @@
 
 ## Contributing
 
-- [Contributing Guide](https://github.com/modern-js-dev/codesmith/blob/main/CONTRIBUTING.md)
+- [Contributing Guide](https://github.com/web-infra-dev/codesmith/blob/main/CONTRIBUTING.md)

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -2,8 +2,8 @@
   "name": "@modern-js/inquirer-types",
   "description": "codesmith inquirer plugin to custom question",
   "homepage": "https://modernjs.dev",
-  "bugs": "https://github.com/modern-js-dev/codesmith/issues",
-  "repository": "modern-js-dev/codesmith",
+  "bugs": "https://github.com/web-infra-dev/codesmith/issues",
+  "repository": "web-infra-dev/codesmith",
   "license": "MIT",
   "keywords": [
     "react",


### PR DESCRIPTION
## Description

Rename GitHub organization from `modern-js-dev` to `web-infra-dev`.