### PR TITLE
Release v2.2.5

### DIFF
--- a/.changeset/dull-plums-camp.md
+++ b/.changeset/dull-plums-camp.md
@@ -1,5 +1,0 @@
----
-'@modern-js/codesmith': patch
----
-
-feat: run generator support relative path

--- a/.changeset/selfish-meals-matter.md
+++ b/.changeset/selfish-meals-matter.md
@@ -1,5 +1,0 @@
----
-'@modern-js/codesmith': patch
----
-
-feat: when specifying a version number, ignore get the version number while downloading the generator package.

--- a/packages/api/app/CHANGELOG.md
+++ b/packages/api/app/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/codesmith-api-app
 
+## 2.2.5
+
+### Patch Changes
+
+- Updated dependencies [cde9b37]
+- Updated dependencies [cde9b37]
+  - @modern-js/codesmith@2.2.5
+  - @modern-js/codesmith-api-ejs@2.2.5
+  - @modern-js/codesmith-api-fs@2.2.5
+  - @modern-js/codesmith-api-git@2.2.5
+  - @modern-js/codesmith-api-handlebars@2.2.5
+  - @modern-js/codesmith-api-npm@2.2.5
+  - @modern-js/codesmith-formily@2.2.5
+
 ## 2.2.4
 
 ### Patch Changes

--- a/packages/api/app/package.json
+++ b/packages/api/app/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -42,7 +42,7 @@
     "inquirer": "8.1.3"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.2.4"
+    "@modern-js/codesmith": "workspace:^2.2.5"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/ejs/CHANGELOG.md
+++ b/packages/api/ejs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-ejs
 
+## 2.2.5
+
+### Patch Changes
+
+- Updated dependencies [cde9b37]
+- Updated dependencies [cde9b37]
+  - @modern-js/codesmith@2.2.5
+
 ## 2.2.4
 
 ### Patch Changes

--- a/packages/api/ejs/package.json
+++ b/packages/api/ejs/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -32,7 +32,7 @@
     "ejs": "^3.1.9"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.2.4"
+    "@modern-js/codesmith": "workspace:^2.2.5"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/fs/CHANGELOG.md
+++ b/packages/api/fs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-fs
 
+## 2.2.5
+
+### Patch Changes
+
+- Updated dependencies [cde9b37]
+- Updated dependencies [cde9b37]
+  - @modern-js/codesmith@2.2.5
+
 ## 2.2.4
 
 ### Patch Changes

--- a/packages/api/fs/package.json
+++ b/packages/api/fs/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -31,7 +31,7 @@
     "@babel/runtime": "^7.21.0"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.2.4"
+    "@modern-js/codesmith": "workspace:^2.2.5"
   },
   "devDependencies": {
     "@modern-js/utils": "^2.18.0",

--- a/packages/api/git/CHANGELOG.md
+++ b/packages/api/git/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-git
 
+## 2.2.5
+
+### Patch Changes
+
+- Updated dependencies [cde9b37]
+- Updated dependencies [cde9b37]
+  - @modern-js/codesmith@2.2.5
+
 ## 2.2.4
 
 ### Patch Changes

--- a/packages/api/git/package.json
+++ b/packages/api/git/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -32,7 +32,7 @@
     "@modern-js/utils": "^2.18.0"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.2.4"
+    "@modern-js/codesmith": "workspace:^2.2.5"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/handlebars/CHANGELOG.md
+++ b/packages/api/handlebars/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-handlebars
 
+## 2.2.5
+
+### Patch Changes
+
+- Updated dependencies [cde9b37]
+- Updated dependencies [cde9b37]
+  - @modern-js/codesmith@2.2.5
+
 ## 2.2.4
 
 ### Patch Changes

--- a/packages/api/handlebars/package.json
+++ b/packages/api/handlebars/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -32,7 +32,7 @@
     "handlebars": "^4.7.7"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.2.4"
+    "@modern-js/codesmith": "workspace:^2.2.5"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/json/CHANGELOG.md
+++ b/packages/api/json/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-json
 
+## 2.2.5
+
+### Patch Changes
+
+- Updated dependencies [cde9b37]
+- Updated dependencies [cde9b37]
+  - @modern-js/codesmith@2.2.5
+
 ## 2.2.4
 
 ### Patch Changes

--- a/packages/api/json/package.json
+++ b/packages/api/json/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/api/npm/CHANGELOG.md
+++ b/packages/api/npm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-npm
 
+## 2.2.5
+
+### Patch Changes
+
+- Updated dependencies [cde9b37]
+- Updated dependencies [cde9b37]
+  - @modern-js/codesmith@2.2.5
+
 ## 2.2.4
 
 ### Patch Changes

--- a/packages/api/npm/package.json
+++ b/packages/api/npm/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/codesmith-cli
 
+## 2.2.5
+
 ## 2.2.4
 
 ## 2.2.3

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith
 
+## 2.2.5
+
+### Patch Changes
+
+- cde9b37: feat: run generator support relative path
+- cde9b37: feat: when specifying a version number, ignore get the version number while downloading the generator package.
+
 ## 2.2.4
 
 ## 2.2.3

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/formily/CHANGELOG.md
+++ b/packages/formily/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-formily
 
+## 2.2.5
+
+### Patch Changes
+
+- Updated dependencies [cde9b37]
+- Updated dependencies [cde9b37]
+  - @modern-js/codesmith@2.2.5
+
 ## 2.2.4
 
 ### Patch Changes

--- a/packages/formily/package.json
+++ b/packages/formily/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -35,7 +35,7 @@
     "inquirer": "^8.2.5"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.2.4"
+    "@modern-js/codesmith": "workspace:^2.2.5"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/inquirer/CHANGELOG.md
+++ b/packages/inquirer/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/inquirer-types
 
+## 2.2.5
+
 ## 2.2.4
 
 ## 2.2.3

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION



## Features:
- [#110](https://github.com/web-infra-dev/codesmith/pull/110) feat: run generator support relative path
- [#110](https://github.com/web-infra-dev/codesmith/pull/110) feat: when specifying a version number, ignore get the version number while downloading the generator package.

