### PR TITLE
Release v2.6.2

### DIFF
--- a/.changeset/dull-lies-sneeze.md
+++ b/.changeset/dull-lies-sneeze.md
@@ -1,7 +1,0 @@
----
-"@modern-js/codesmith": patch
----
-
-fix: get npm version registry not work && add get npm info cache
-
-fix: 修复获取 npm 版本 registry 不生效 && 新增获取 npm 信息缓存

--- a/packages/api/app/CHANGELOG.md
+++ b/packages/api/app/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @modern-js/codesmith-api-app
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+  - @modern-js/codesmith-api-ejs@2.6.2
+  - @modern-js/codesmith-api-fs@2.6.2
+  - @modern-js/codesmith-api-git@2.6.2
+  - @modern-js/codesmith-api-handlebars@2.6.2
+  - @modern-js/codesmith-api-npm@2.6.2
+  - @modern-js/codesmith-formily@2.6.2
+  - @modern-js/codesmith-utils@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/api/app/package.json
+++ b/packages/api/app/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -43,7 +43,7 @@
     "inquirer": "8.1.3"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.6.1"
+    "@modern-js/codesmith": "workspace:^2.6.2"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/ejs/CHANGELOG.md
+++ b/packages/api/ejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-ejs
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/api/ejs/package.json
+++ b/packages/api/ejs/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -33,7 +33,7 @@
     "ejs": "^3.1.9"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.6.1"
+    "@modern-js/codesmith": "workspace:^2.6.2"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/fs/CHANGELOG.md
+++ b/packages/api/fs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-fs
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+  - @modern-js/codesmith-utils@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/api/fs/package.json
+++ b/packages/api/fs/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -33,7 +33,7 @@
     "@modern-js/codesmith-utils": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.6.1"
+    "@modern-js/codesmith": "workspace:^2.6.2"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/git/CHANGELOG.md
+++ b/packages/api/git/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-git
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+  - @modern-js/codesmith-utils@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/api/git/package.json
+++ b/packages/api/git/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -33,7 +33,7 @@
     "@modern-js/codesmith-utils": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.6.1"
+    "@modern-js/codesmith": "workspace:^2.6.2"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/handlebars/CHANGELOG.md
+++ b/packages/api/handlebars/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-handlebars
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/api/handlebars/package.json
+++ b/packages/api/handlebars/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -33,7 +33,7 @@
     "handlebars": "^4.7.7"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.6.1"
+    "@modern-js/codesmith": "workspace:^2.6.2"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/json/CHANGELOG.md
+++ b/packages/api/json/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-json
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/api/json/package.json
+++ b/packages/api/json/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/api/npm/CHANGELOG.md
+++ b/packages/api/npm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-api-npm
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+  - @modern-js/codesmith-utils@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/api/npm/package.json
+++ b/packages/api/npm/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -33,7 +33,7 @@
     "@modern-js/codesmith-utils": "workspace:*"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.6.1"
+    "@modern-js/codesmith": "workspace:^2.6.2"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-cli
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+  - @modern-js/codesmith-utils@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @modern-js/codesmith
 
+## 2.6.2
+
+### Patch Changes
+
+- 523d7ec: fix: get npm version registry not work && add get npm info cache
+
+  fix: 修复获取 npm 版本 registry 不生效 && 新增获取 npm 信息缓存
+
+  - @modern-js/codesmith-utils@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/formily/CHANGELOG.md
+++ b/packages/formily/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modern-js/codesmith-formily
 
+## 2.6.2
+
+### Patch Changes
+
+- Updated dependencies [523d7ec]
+  - @modern-js/codesmith@2.6.2
+  - @modern-js/codesmith-utils@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/formily/package.json
+++ b/packages/formily/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
@@ -36,7 +36,7 @@
     "inquirer": "^8.2.5"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.6.1"
+    "@modern-js/codesmith": "workspace:^2.6.2"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/global/CHANGELOG.md
+++ b/packages/global/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/codesmith-global
 
+## 2.6.2
+
 ## 2.6.1
 
 ## 2.6.0

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "main": "./dist/index.js",
   "publishConfig": {

--- a/packages/inquirer/CHANGELOG.md
+++ b/packages/inquirer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/inquirer-types
 
+## 2.6.2
+
+### Patch Changes
+
+- @modern-js/codesmith-utils@2.6.2
+
 ## 2.6.1
 
 ### Patch Changes

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/codesmith-utils
 
+## 2.6.2
+
 ## 2.6.1
 
 ## 2.6.0

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.6.1",
+  "version": "2.6.2",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION
## What's Changed
### Bug Fixes 🐞
- fix: get npm version registry not work && add get npm info cache by @caohuilin in https://github.com/web-infra-dev/codesmith/pull/164
## 更新内容
### Bug 修复 🐞
- fix: 修复获取 npm 版本 registry 不生效 && 新增获取 npm 信息缓存 由 @caohuilin 实现， 详情可查看 https://github.com/web-infra-dev/codesmith/pull/164