### PR TITLE
fix: check cache add `package.json` file

### DIFF
--- a/.changeset/tough-monkeys-buy.md
+++ b/.changeset/tough-monkeys-buy.md
@@ -1,0 +1,7 @@
+---
+"@modern-js/codesmith": patch
+---
+
+fix: check cache add `package.json` file
+
+fix: 校验缓存是否有效增加 `package.json` 文件

--- a/packages/core/src/utils/downloadPackage.ts
+++ b/packages/core/src/utils/downloadPackage.ts
@@ -60,11 +60,14 @@ export async function getGeneratorVersion(
 
 async function isValidCache(cacheDir: string, pkgName: string) {
   /* generator cache can use
-   * 1. .codesmith.completed exist
+   * 1. .codesmith.completed && package.json exist
    * 2. cache time is within the validity period
    * 3. 对于 @modern-js/codesmith-global 包，缓存一直有效
    */
-  if (await fsExists(`${cacheDir}/.codesmith.completed`)) {
+  if (
+    (await fsExists(`${cacheDir}/.codesmith.completed`)) &&
+    (await fsExists(`${cacheDir}/package.json`))
+  ) {
     if (pkgName === '@modern-js/codesmith-global') {
       return true;
     }


### PR DESCRIPTION
Often there is a situation where the cache is valid but `package.json` cannot be found. When validating the cache, add the existence of the `package.json` file.